### PR TITLE
fix: Not building main branch due to false alarm in tests

### DIFF
--- a/pkgs/core/e2e_provider_test.go
+++ b/pkgs/core/e2e_provider_test.go
@@ -29,8 +29,9 @@ func TestFetchLogs(t *testing.T) {
 	run.Name = "test-run"
 	run.Namespace = "default"
 
+	data := config.NewData("jx-scm", map[string]string{}, &config.FakeValidator{}, &logging.InternalLogger{})
 	prp := PipelineRunProvider{logger: logging.CreateLogger(true)}
-	assert.Contains(t, prp.fetchLogs(&run, config.Data{}), "Bread for you")
+	assert.Contains(t, prp.fetchLogs(&run, data), "Bread for you")
 }
 
 // TestSkippedTask is checking if task marked as skipped is shown as skipped. Previously it was recognized as "pending"

--- a/pkgs/testpkg/helpers.go
+++ b/pkgs/testpkg/helpers.go
@@ -21,10 +21,10 @@ func Kubectl(argv []string) error {
 
 func WaitForPipelineFinishedByName(ns string, name string) {
 	Kubectl([]string{"wait", "--for=condition=Succeeded", "pipelinerun", "-n", ns, name})
-	time.Sleep(5 * time.Second)
+	time.Sleep(2 * time.Second)
 }
 
 func WaitForPipelineFinishedByLabel(ns string, label string) {
 	Kubectl([]string{"wait", "--for=condition=Succeeded", "pipelinerun", "-n", ns, "-l", label})
-	time.Sleep(5 * time.Second)
+	time.Sleep(2 * time.Second)
 }

--- a/test_data/test-run.yaml
+++ b/test_data/test-run.yaml
@@ -17,7 +17,7 @@ spec:
                       - name: username
                         default: $(params.username)
                   steps:
-                      - image: busybox
+                      - image: ghcr.io/containerd/busybox:1.36
                         name: print
                         script: |
                             sleep 3


### PR DESCRIPTION
Those tests are end-to-end tests which makes them unstable and dependent on many factors therefore this is a maintenance PR